### PR TITLE
adding option to have encryption at rest inside a vpc

### DIFF
--- a/main_vpc.tf
+++ b/main_vpc.tf
@@ -36,6 +36,10 @@ resource "aws_elasticsearch_domain" "es_vpc" {
   domain_name           = "tf-${var.domain_name}"
   elasticsearch_version = "${var.es_version}"
 
+  encrypt_at_rest       = {
+    enabled = "${var.encrypt_at_rest}"
+  }
+  
   cluster_config {
     instance_type            = "${var.instance_type}"
     instance_count           = "${var.instance_count}"

--- a/variables.tf
+++ b/variables.tf
@@ -23,6 +23,11 @@ variable "dedicated_master_type" {
   default     = false
 }
 
+variable "encrypt_at_rest" {
+  description = "Enable encrption at rest (only specific instance family types support it: m4, c4, r4, i2, i3 default: false)"
+  default     = false
+}
+
 variable "management_iam_roles" {
   description = "List of IAM role ARNs from which to permit management traffic (default ['*']).  Note that a client must match both the IP address and the IAM role patterns in order to be permitted access."
   type        = "list"


### PR DESCRIPTION
Adding option for encryption at rest when creating an elasticsearch domain within a vpc.  Variable is default false to ensure backwards compatibility 