### PR TITLE
Make prefix optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ For a production deployment it may also make sense to use EBS volumes rather tha
 None (but `domain_name` and `management_public_ip_addresses` are strongly recommended).
 
 #### Optional
-- `domain_name` - unique identifier for the domain.  The module will prefix it with `tf-`. _e.g._ `domain_name = foo` will result in a domain called `tf-foo`.
+- `domain_name` - unique identifier for the domain.
+- `domain_prefix` - A string to be prefixed to the domain, if `use_prefix` is true. Default is `tf-`. _e.g._ `domain_name = foo` will result in a domain called `tf-foo`.
+- `use_prefix` - A boolean flag indicating whether or not to use the domain_prefix. Default is `true`.
 - `es_version` - Elasticsearch version.
 - `instance_type` - Elasticsearch instance type to use for data nodes (and dedicated master nodes unless otherwise specified).
 - `instance_count` - Number of instances in the cluster.

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,3 @@
+locals {
+  domain_name = "${var.use_prefix ? join("", list(var.domain_prefix, var.domain_name)) : var.domain_name}"
+}

--- a/main.tf
+++ b/main.tf
@@ -29,7 +29,7 @@ data "aws_iam_policy_document" "es_management_access" {
 
 resource "aws_elasticsearch_domain" "es" {
   count                 = "${length(var.vpc_options["subnet_ids"]) > 0 ? 0 : 1}"
-  domain_name           = "tf-${var.domain_name}"
+  domain_name           = "${local.domain_name}"
   elasticsearch_version = "${var.es_version}"
 
   cluster_config {
@@ -53,13 +53,13 @@ resource "aws_elasticsearch_domain" "es" {
     automated_snapshot_start_hour = "${var.snapshot_start_hour}"
   }
   tags = "${merge(var.tags, map(
-    "Domain", "${var.domain_name}"
+    "Domain", "${local.domain_name}"
   ))}"
 }
 
 resource "aws_elasticsearch_domain_policy" "es_management_access" {
   count           = "${length(var.vpc_options["subnet_ids"]) > 0 ? 0 : 1}"
-  domain_name     = "tf-${var.domain_name}"
+  domain_name     = "${local.domain_name}"
   access_policies = "${data.aws_iam_policy_document.es_management_access.json}"
 }
 

--- a/main_vpc.tf
+++ b/main_vpc.tf
@@ -32,7 +32,7 @@ data "aws_iam_policy_document" "es_vpc_management_access" {
 
 resource "aws_elasticsearch_domain" "es_vpc" {
   count                 = "${length(var.vpc_options["subnet_ids"]) > 0 ? 1 : 0}"
-  domain_name           = "tf-${var.domain_name}"
+  domain_name           = "${local.domain_name}"
   elasticsearch_version = "${var.es_version}"
 
   encrypt_at_rest = {
@@ -68,6 +68,6 @@ resource "aws_elasticsearch_domain" "es_vpc" {
 
 resource "aws_elasticsearch_domain_policy" "es_vpc_management_access" {
   count           = "${length(var.vpc_options["subnet_ids"]) > 0 ? 1 : 0}"
-  domain_name     = "tf-${var.domain_name}"
+  domain_name     = "${local.domain_name}"
   access_policies = "${data.aws_iam_policy_document.es_vpc_management_access.json}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "domain_name" {
-  description = "Domain name for Elasticsearch cluster (will be prefixed with 'tf-')"
+  description = "Domain name for Elasticsearch cluster"
   default     = "es-domain"
 }
 
@@ -79,6 +79,16 @@ variable "tags" {
   description = "tags to apply to all resources"
   type        = "map"
   default     = {}
+}
+
+variable "use_prefix" {
+  description = "Flag indicating whether or not to use the domain_prefix. Default: true"
+  default     = true
+}
+
+variable "domain_prefix" {
+  description = "String to be prefixed to search domain. Default: tf-"
+  default     = "tf-"
 }
 
 # vim: set et fenc=utf-8 ff=unix ft=terraform sts=2 sw=2 ts=2 : 


### PR DESCRIPTION
This change makes the domain prefix both configurable and optional.

Defaults are `domain_prefix = "tf-"` and `use_prefix = true` so default behaviour remains the same.