### PR TITLE
fix dedicated_master_type variable type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -30,8 +30,8 @@ variable "instance_count" {
 
 variable "dedicated_master_type" {
   description = "ES instance type to be used for dedicated masters (default same as instance_type)"
-  type        = bool
-  default     = false
+  type        = string
+  default     = "false"
 }
 
 variable "encrypt_at_rest" {


### PR DESCRIPTION
`terraform plan` fails with:
```
Error: Invalid value for module argument

  on efk.tf line 40, in module "es":
  40:   dedicated_master_type      = "m4.large.elasticsearch"

The given value is not suitable for child module variable
"dedicated_master_type" defined at .terraform/modules/es/variables.tf:31,1-33:
a bool is required.
```
Since dedicated_master_type is a string and not a bool.
