### PR TITLE
Add support for 'availability_zone_count'

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ module "es" {
 | encrypt\_at\_rest | Enable encrption at rest (only specific instance family types support it: m4, c4, r4, i2, i3 default: false) | bool | `"false"` | no |
 | es\_version | Version of Elasticsearch to deploy (default 5.1) | string | `"5.1"` | no |
 | es\_zone\_awareness | Enable zone awareness for Elasticsearch cluster (default false) | bool | `"false"` | no |
-| es\_zone\_awareness\_count | Set the number of zones for the Elasticsearch cluster zone awareness (default 3) | number `"3"` | no |
+| es\_zone\_awareness\_count | Set the number of zones for the Elasticsearch cluster zone awareness (default 2) | number `"2"` | no |
 | instance\_count | Number of data nodes in the cluster (default 6) | number | `"6"` | no |
 | instance\_type | ES instance type for data nodes in the cluster (default t2.small.elasticsearch) | string | `"t2.small.elasticsearch"` | no |
 | kms\_key\_id | KMS key used for elasticsearch | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ module "es" {
 | encrypt\_at\_rest | Enable encrption at rest (only specific instance family types support it: m4, c4, r4, i2, i3 default: false) | bool | `"false"` | no |
 | es\_version | Version of Elasticsearch to deploy (default 5.1) | string | `"5.1"` | no |
 | es\_zone\_awareness | Enable zone awareness for Elasticsearch cluster (default false) | bool | `"false"` | no |
-| es\_zone\_awareness\_count | Set the number of zones for the Elasticsearch cluster zone awareness (default 2) | number `"2"` | no |
+| es\_zone\_awareness\_count | Set the number of zones for the Elasticsearch cluster zone awareness (default 2) | number | `"2"` | no |
 | instance\_count | Number of data nodes in the cluster (default 6) | number | `"6"` | no |
 | instance\_type | ES instance type for data nodes in the cluster (default t2.small.elasticsearch) | string | `"t2.small.elasticsearch"` | no |
 | kms\_key\_id | KMS key used for elasticsearch | string | `""` | no |

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ module "es" {
 | encrypt\_at\_rest | Enable encrption at rest (only specific instance family types support it: m4, c4, r4, i2, i3 default: false) | bool | `"false"` | no |
 | es\_version | Version of Elasticsearch to deploy (default 5.1) | string | `"5.1"` | no |
 | es\_zone\_awareness | Enable zone awareness for Elasticsearch cluster (default false) | bool | `"false"` | no |
+| es\_zone\_awareness\_count | Set the number of zones for the Elasticsearch cluster zone awareness (default 3) | number `"3"` | no |
 | instance\_count | Number of data nodes in the cluster (default 6) | number | `"6"` | no |
 | instance\_type | ES instance type for data nodes in the cluster (default t2.small.elasticsearch) | string | `"t2.small.elasticsearch"` | no |
 | kms\_key\_id | KMS key used for elasticsearch | string | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -46,6 +46,9 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_count   = var.instance_count >= var.dedicated_master_threshold ? 3 : 0
     dedicated_master_type    = var.instance_count >= var.dedicated_master_threshold ? var.dedicated_master_type != "false" ? var.dedicated_master_type : var.instance_type : ""
     zone_awareness_enabled   = var.es_zone_awareness
+    zone_awareness_config {
+      availability_zone_count = var.es_zone_awareness_count
+    }
   }
 
   advanced_options = var.advanced_options

--- a/main_vpc.tf
+++ b/main_vpc.tf
@@ -47,6 +47,9 @@ resource "aws_elasticsearch_domain" "es_vpc" {
     dedicated_master_count   = var.instance_count >= var.dedicated_master_threshold ? 3 : 0
     dedicated_master_type    = var.instance_count >= var.dedicated_master_threshold ? var.dedicated_master_type != "false" ? var.dedicated_master_type : var.instance_type : ""
     zone_awareness_enabled   = var.es_zone_awareness
+    zone_awareness_config {
+      availability_zone_count = var.es_zone_awareness_count
+    }
   }
 
   advanced_options = var.advanced_options

--- a/variables.tf
+++ b/variables.tf
@@ -59,9 +59,9 @@ variable "es_zone_awareness" {
 }
 
 variable "es_zone_awareness_count" {
-  description = "Number of availability zones used for data nodes (default 3)"
+  description = "Number of availability zones used for data nodes (default 2)"
   type        = number
-  default     = 3
+  default     = 2
 }
 
 variable "ebs_volume_size" {

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "es_zone_awareness" {
   default     = false
 }
 
+variable "es_zone_awareness_count" {
+  description = "Number of availability zones used for data nodes (default 3)"
+  type        = number
+  default     = 3
+}
+
 variable "ebs_volume_size" {
   description = "Optionally use EBS volumes for data storage by specifying volume size in GB (default 0)"
   type        = number


### PR DESCRIPTION
Add support for `availability_zone_count` (defaults to 2):  https://www.terraform.io/docs/providers/aws/r/elasticsearch_domain.html#availability_zone_count

Added in the AWS provider `2.20.0`: https://github.com/terraform-providers/terraform-provider-aws/issues/7504#issuecomment-512900927