### PR TITLE
Add `dynamic` condition to inject or not `awarness_config` block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,8 +46,11 @@ resource "aws_elasticsearch_domain" "es" {
     dedicated_master_count   = var.instance_count >= var.dedicated_master_threshold ? 3 : 0
     dedicated_master_type    = var.instance_count >= var.dedicated_master_threshold ? var.dedicated_master_type != "false" ? var.dedicated_master_type : var.instance_type : ""
     zone_awareness_enabled   = var.es_zone_awareness
-    zone_awareness_config {
-      availability_zone_count = var.es_zone_awareness_count
+    dynamic "zone_awareness_config" {
+      for_each = var.es_zone_awareness ? [var.es_zone_awareness_count] : []
+      content {
+        availability_zone_count = zone_awareness_config.value
+      }
     }
   }
 

--- a/main_vpc.tf
+++ b/main_vpc.tf
@@ -47,8 +47,11 @@ resource "aws_elasticsearch_domain" "es_vpc" {
     dedicated_master_count   = var.instance_count >= var.dedicated_master_threshold ? 3 : 0
     dedicated_master_type    = var.instance_count >= var.dedicated_master_threshold ? var.dedicated_master_type != "false" ? var.dedicated_master_type : var.instance_type : ""
     zone_awareness_enabled   = var.es_zone_awareness
-    zone_awareness_config {
-      availability_zone_count = var.es_zone_awareness_count
+    dynamic "zone_awareness_config" {
+      for_each = var.es_zone_awareness ? [var.es_zone_awareness_count] : []
+      content {
+        availability_zone_count = zone_awareness_config.value
+      }
     }
   }
 


### PR DESCRIPTION
The solution is to dynamically inject `awarness_config` block based on the variable.

Sources: https://www.hashicorp.com/blog/hashicorp-terraform-0-12-preview-for-and-for-each/#dynamic-nested-blocks

Fixes #40 